### PR TITLE
fix(llama): use ggml_type to build on Windows

### DIFF
--- a/llama-rs/src/llama.rs
+++ b/llama-rs/src/llama.rs
@@ -214,7 +214,7 @@ impl LlamaModel {
                 };
             }
 
-            fn ggml_type_sizef(x: u32) -> f64 {
+            fn ggml_type_sizef(x: ggml_raw::ggml_type) -> f64 {
                 (unsafe { ggml_raw::ggml_type_sizef(x) }) as f64
             }
 


### PR DESCRIPTION
Pretty simple fix. Encountered this in my attempt as well - `ggml_type` can be different between operating systems thanks to the loosy-goosy C integer rules 🙃 