### PR TITLE
Remove bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,28 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
- "which",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,30 +30,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-sys"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -113,12 +71,6 @@ checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
-
-[[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
@@ -169,15 +121,8 @@ dependencies = [
 name = "ggml-raw"
 version = "0.1.0"
 dependencies = [
- "bindgen",
  "cc",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
@@ -229,32 +174,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -302,22 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,12 +251,6 @@ name = "partial_sort"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "ppv-lite86"
@@ -447,12 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,12 +360,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "strsim"
@@ -535,17 +424,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "winapi"

--- a/ggml-raw/Cargo.toml
+++ b/ggml-raw/Cargo.toml
@@ -1,6 +1,3 @@
-[build-dependencies.bindgen]
-version = "^0.62.0"
-
 [build-dependencies.cc]
 version = "^1.0"
 

--- a/ggml-raw/build.rs
+++ b/ggml-raw/build.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::path::PathBuf;
 
 fn main() {
     // By default, this crate will attempt to compile ggml with the features of your host system if
@@ -14,7 +13,6 @@ fn main() {
 
     // This is a very basic heuristic for applying compile flags.
     // Feel free to update this to fit your operating system.
-
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let is_release = env::var("PROFILE").unwrap() == "release";
     let compiler = build.get_compiler();
@@ -59,22 +57,6 @@ fn main() {
         build.define("NDEBUG", None);
     }
     build.compile("ggml");
-
-    let bindings = bindgen::Builder::default()
-        .header("ggml/ggml.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .allowlist_function("ggml_.*")
-        .allowlist_type("ggml_.*")
-        .allowlist_var("ggml_.*")
-        .allowlist_file("ggml_.*")
-        .generate()
-        .expect("Unable to generate bindings");
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
 }
 
 fn get_supported_target_features() -> std::collections::HashSet<String> {

--- a/ggml-raw/src/lib.rs
+++ b/ggml-raw/src/lib.rs
@@ -1,5 +1,231 @@
-#![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+use std::os::raw::{c_int, c_void};
+
+pub type ggml_type = c_int;
+pub const GGML_TYPE_Q4_0: ggml_type = 0;
+pub const GGML_TYPE_Q4_1: ggml_type = 1;
+pub const GGML_TYPE_I8: ggml_type = 2;
+pub const GGML_TYPE_I16: ggml_type = 3;
+pub const GGML_TYPE_I32: ggml_type = 4;
+pub const GGML_TYPE_F16: ggml_type = 5;
+pub const GGML_TYPE_F32: ggml_type = 6;
+pub const GGML_TYPE_COUNT: ggml_type = 7;
+
+pub type ggml_op = c_int;
+pub const GGML_OP_NONE: ggml_op = 0;
+pub const GGML_OP_DUP: ggml_op = 1;
+pub const GGML_OP_ADD: ggml_op = 2;
+pub const GGML_OP_SUB: ggml_op = 3;
+pub const GGML_OP_MUL: ggml_op = 4;
+pub const GGML_OP_DIV: ggml_op = 5;
+pub const GGML_OP_SQR: ggml_op = 6;
+pub const GGML_OP_SQRT: ggml_op = 7;
+pub const GGML_OP_SUM: ggml_op = 8;
+pub const GGML_OP_MEAN: ggml_op = 9;
+pub const GGML_OP_REPEAT: ggml_op = 10;
+pub const GGML_OP_ABS: ggml_op = 11;
+pub const GGML_OP_SGN: ggml_op = 12;
+pub const GGML_OP_NEG: ggml_op = 13;
+pub const GGML_OP_STEP: ggml_op = 14;
+pub const GGML_OP_RELU: ggml_op = 15;
+pub const GGML_OP_GELU: ggml_op = 16;
+pub const GGML_OP_SILU: ggml_op = 17;
+pub const GGML_OP_NORM: ggml_op = 18;
+pub const GGML_OP_MUL_MAT: ggml_op = 19;
+pub const GGML_OP_SCALE: ggml_op = 20;
+pub const GGML_OP_CPY: ggml_op = 21;
+pub const GGML_OP_RESHAPE: ggml_op = 22;
+pub const GGML_OP_VIEW: ggml_op = 23;
+pub const GGML_OP_PERMUTE: ggml_op = 24;
+pub const GGML_OP_TRANSPOSE: ggml_op = 25;
+pub const GGML_OP_GET_ROWS: ggml_op = 26;
+pub const GGML_OP_DIAG_MASK_INF: ggml_op = 27;
+pub const GGML_OP_SOFT_MAX: ggml_op = 28;
+pub const GGML_OP_ROPE: ggml_op = 29;
+pub const GGML_OP_CONV_1D_1S: ggml_op = 30;
+pub const GGML_OP_CONV_1D_2S: ggml_op = 31;
+pub const GGML_OP_FLASH_ATTN: ggml_op = 32;
+pub const GGML_OP_FLASH_FF: ggml_op = 33;
+pub const GGML_OP_COUNT: ggml_op = 34;
+
+pub type ggml_context = c_void;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ggml_tensor {
+    pub type_: ggml_type,
+    pub n_dims: c_int,
+    pub ne: [c_int; 4usize],
+    pub nb: [usize; 4usize],
+    pub op: ggml_op,
+    pub is_param: bool,
+    pub grad: *mut ggml_tensor,
+    pub src0: *mut ggml_tensor,
+    pub src1: *mut ggml_tensor,
+    pub opt: [*mut ggml_tensor; 4usize],
+    pub n_tasks: c_int,
+    pub perf_runs: c_int,
+    pub perf_cycles: i64,
+    pub perf_time_us: i64,
+    pub data: *mut c_void,
+    pub padding: [::std::os::raw::c_char; 8usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ggml_cgraph {
+    pub n_nodes: c_int,
+    pub n_leafs: c_int,
+    pub n_threads: c_int,
+    pub work_size: usize,
+    pub work: *mut ggml_tensor,
+    pub nodes: [*mut ggml_tensor; 4096usize],
+    pub grads: [*mut ggml_tensor; 4096usize],
+    pub leafs: [*mut ggml_tensor; 4096usize],
+    pub perf_runs: c_int,
+    pub perf_cycles: i64,
+    pub perf_time_us: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ggml_init_params {
+    pub mem_size: usize,
+    pub mem_buffer: *mut c_void,
+}
+
+extern "C" {
+    pub fn ggml_nelements(tensor: *const ggml_tensor) -> c_int;
+
+    pub fn ggml_nbytes(tensor: *const ggml_tensor) -> usize;
+
+    pub fn ggml_blck_size(type_: ggml_type) -> c_int;
+
+    pub fn ggml_type_size(type_: ggml_type) -> usize;
+
+    pub fn ggml_type_sizef(type_: ggml_type) -> f32;
+
+    pub fn ggml_element_size(tensor: *const ggml_tensor) -> usize;
+
+    pub fn ggml_init(params: ggml_init_params) -> *mut ggml_context;
+
+    pub fn ggml_free(ctx: *mut ggml_context);
+
+    pub fn ggml_used_mem(ctx: *const ggml_context) -> usize;
+
+    pub fn ggml_new_tensor_1d(
+        ctx: *mut ggml_context,
+        type_: ggml_type,
+        ne0: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_new_tensor_2d(
+        ctx: *mut ggml_context,
+        type_: ggml_type,
+        ne0: c_int,
+        ne1: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_new_tensor_3d(
+        ctx: *mut ggml_context,
+        type_: ggml_type,
+        ne0: c_int,
+        ne1: c_int,
+        ne2: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_new_f32(ctx: *mut ggml_context, value: f32) -> *mut ggml_tensor;
+
+    pub fn ggml_get_data(tensor: *const ggml_tensor) -> *mut c_void;
+
+    pub fn ggml_add(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_mul(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_repeat(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_silu(ctx: *mut ggml_context, a: *mut ggml_tensor) -> *mut ggml_tensor;
+
+    pub fn ggml_norm(ctx: *mut ggml_context, a: *mut ggml_tensor) -> *mut ggml_tensor;
+
+    pub fn ggml_mul_mat(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_scale(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_cpy(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_reshape_3d(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        ne0: c_int,
+        ne1: c_int,
+        ne2: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_view_1d(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        ne0: c_int,
+        offset: usize,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_permute(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        axis0: c_int,
+        axis1: c_int,
+        axis2: c_int,
+        axis3: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_get_rows(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        b: *mut ggml_tensor,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_diag_mask_inf(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        n_past: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_soft_max(ctx: *mut ggml_context, a: *mut ggml_tensor) -> *mut ggml_tensor;
+
+    pub fn ggml_rope(
+        ctx: *mut ggml_context,
+        a: *mut ggml_tensor,
+        n_past: c_int,
+        n_dims: c_int,
+        mode: c_int,
+    ) -> *mut ggml_tensor;
+
+    pub fn ggml_build_forward_expand(cgraph: *mut ggml_cgraph, tensor: *mut ggml_tensor);
+
+    pub fn ggml_graph_compute(ctx: *mut ggml_context, cgraph: *mut ggml_cgraph);
+}

--- a/llama-rs/src/ggml.rs
+++ b/llama-rs/src/ggml.rs
@@ -6,11 +6,11 @@ use std::{
 
 pub use ggml_raw::ggml_type as Type;
 
-pub const TYPE_Q4_0: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_Q4_0;
-pub const TYPE_Q4_1: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_Q4_1;
-pub const TYPE_I32: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_I32;
-pub const TYPE_F16: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_F16;
-pub const TYPE_F32: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_F32;
+pub const TYPE_Q4_0: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_Q4_0;
+pub const TYPE_Q4_1: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_Q4_1;
+pub const TYPE_I32: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_I32;
+pub const TYPE_F16: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_F16;
+pub const TYPE_F32: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_F32;
 
 /// Acts as a RAII-guard over a `ggml_raw::ggml_context`, allocating via
 /// ggml_init and dropping via ggml_free

--- a/llama-rs/src/ggml.rs
+++ b/llama-rs/src/ggml.rs
@@ -8,12 +8,9 @@ pub use ggml_raw::ggml_type as Type;
 
 pub const TYPE_Q4_0: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_Q4_0;
 pub const TYPE_Q4_1: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_Q4_1;
-pub const TYPE_I8: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_I8;
-pub const TYPE_I16: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_I16;
 pub const TYPE_I32: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_I32;
 pub const TYPE_F16: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_F16;
 pub const TYPE_F32: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_F32;
-pub const TYPE_COUNT: ggml_raw::ggml_type = ggml_raw::ggml_type_GGML_TYPE_COUNT;
 
 /// Acts as a RAII-guard over a `ggml_raw::ggml_context`, allocating via
 /// ggml_init and dropping via ggml_free
@@ -271,4 +268,16 @@ impl ComputationGraph {
     pub fn build_forward_expand(&mut self, tensor: &Tensor) {
         unsafe { ggml_raw::ggml_build_forward_expand(&mut self.inner, tensor.ptr.as_ptr()) }
     }
+}
+
+pub fn type_size(t: Type) -> usize {
+    unsafe { ggml_raw::ggml_type_size(t) }
+}
+
+pub fn type_sizef(x: ggml_raw::ggml_type) -> f64 {
+    (unsafe { ggml_raw::ggml_type_sizef(x) }) as f64
+}
+
+pub fn blck_size(t: Type) -> i32 {
+    unsafe { ggml_raw::ggml_blck_size(t) }
 }

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -316,33 +316,29 @@ impl Model {
                 };
             }
 
-            fn ggml_type_sizef(x: ggml_raw::ggml_type) -> f64 {
-                (unsafe { ggml_raw::ggml_type_sizef(x) }) as f64
-            }
-
             let mut ctx_size: u64 = 0;
 
-            ctx_size += mul!(n_embd, n_vocab, ggml_type_sizef(wtype)); // tok_embeddings
+            ctx_size += mul!(n_embd, n_vocab, ggml::type_sizef(wtype)); // tok_embeddings
 
-            ctx_size += mul!(n_embd, ggml_type_sizef(ggml::TYPE_F32)); // norm
+            ctx_size += mul!(n_embd, ggml::type_sizef(ggml::TYPE_F32)); // norm
 
-            ctx_size += mul!(n_embd, n_vocab, ggml_type_sizef(wtype)); // output
+            ctx_size += mul!(n_embd, n_vocab, ggml::type_sizef(wtype)); // output
 
-            ctx_size += mul!(n_layer, n_embd, ggml_type_sizef(ggml::TYPE_F32)); // attention_norm
+            ctx_size += mul!(n_layer, n_embd, ggml::type_sizef(ggml::TYPE_F32)); // attention_norm
 
-            ctx_size += mul!(n_layer, n_embd, n_embd, ggml_type_sizef(wtype)); // wq
-            ctx_size += mul!(n_layer, n_embd, n_embd, ggml_type_sizef(wtype)); // wk
-            ctx_size += mul!(n_layer, n_embd, n_embd, ggml_type_sizef(wtype)); // wv
-            ctx_size += mul!(n_layer, n_embd, n_embd, ggml_type_sizef(wtype)); // wo
+            ctx_size += mul!(n_layer, n_embd, n_embd, ggml::type_sizef(wtype)); // wq
+            ctx_size += mul!(n_layer, n_embd, n_embd, ggml::type_sizef(wtype)); // wk
+            ctx_size += mul!(n_layer, n_embd, n_embd, ggml::type_sizef(wtype)); // wv
+            ctx_size += mul!(n_layer, n_embd, n_embd, ggml::type_sizef(wtype)); // wo
 
-            ctx_size += mul!(n_layer, n_embd, ggml_type_sizef(ggml::TYPE_F32)); // ffn_norm
+            ctx_size += mul!(n_layer, n_embd, ggml::type_sizef(ggml::TYPE_F32)); // ffn_norm
 
-            ctx_size += mul!(n_layer, n_ff, n_embd, ggml_type_sizef(wtype)); // w1
-            ctx_size += mul!(n_layer, n_ff, n_embd, ggml_type_sizef(wtype)); // w2
-            ctx_size += mul!(n_layer, n_ff, n_embd, ggml_type_sizef(wtype)); // w3
+            ctx_size += mul!(n_layer, n_ff, n_embd, ggml::type_sizef(wtype)); // w1
+            ctx_size += mul!(n_layer, n_ff, n_embd, ggml::type_sizef(wtype)); // w2
+            ctx_size += mul!(n_layer, n_ff, n_embd, ggml::type_sizef(wtype)); // w3
 
-            ctx_size += mul!(n_ctx, n_layer, n_embd, ggml_type_sizef(ggml::TYPE_F32)); // memory_k
-            ctx_size += mul!(n_ctx, n_layer, n_embd, ggml_type_sizef(ggml::TYPE_F32)); // memory_v
+            ctx_size += mul!(n_ctx, n_layer, n_embd, ggml::type_sizef(ggml::TYPE_F32)); // memory_k
+            ctx_size += mul!(n_ctx, n_layer, n_embd, ggml::type_sizef(ggml::TYPE_F32)); // memory_v
 
             ctx_size += (5 + 10 * n_layer) * 256; // object overhead
 
@@ -573,24 +569,16 @@ impl Model {
                     }
                 }
 
-                fn ggml_type_size(t: ggml::Type) -> usize {
-                    unsafe { ggml_raw::ggml_type_size(t) }
-                }
-
-                fn ggml_blck_size(t: ggml::Type) -> i32 {
-                    unsafe { ggml_raw::ggml_blck_size(t) }
-                }
-
                 let bpe = match ftype {
-                    0 => ggml_type_size(ggml::TYPE_F32),
-                    1 => ggml_type_size(ggml::TYPE_F16),
+                    0 => ggml::type_size(ggml::TYPE_F32),
+                    1 => ggml::type_size(ggml::TYPE_F16),
                     2 => {
                         assert_eq!(ne[0] % 64, 0);
-                        ggml_type_size(ggml::TYPE_Q4_0)
+                        ggml::type_size(ggml::TYPE_Q4_0)
                     }
                     3 => {
                         assert_eq!(ne[0] % 64, 0);
-                        ggml_type_size(ggml::TYPE_Q4_1)
+                        ggml::type_size(ggml::TYPE_Q4_1)
                     }
                     _ => {
                         return Err(LoadError::InvalidFtype {
@@ -601,7 +589,7 @@ impl Model {
                 };
 
                 if n_dims == 1 || n_parts == 1 {
-                    if (nelements as usize * bpe) / ggml_blck_size(tensor.get_type()) as usize
+                    if (nelements as usize * bpe) / ggml::blck_size(tensor.get_type()) as usize
                         != tensor.nbytes()
                     {
                         return Err(LoadError::TensorWrongSize {
@@ -624,7 +612,7 @@ impl Model {
 
                     total_size += tensor.nbytes();
                 } else {
-                    if (nelements as usize * bpe) / ggml_blck_size(tensor.get_type()) as usize
+                    if (nelements as usize * bpe) / ggml::blck_size(tensor.get_type()) as usize
                         != tensor.nbytes() / n_parts as usize
                     {
                         return Err(LoadError::TensorWrongSize {
@@ -635,9 +623,9 @@ impl Model {
 
                     if split_type == 0 {
                         let np0 = ne[0];
-                        let row_size = (tensor.get_ne()[0] / ggml_blck_size(tensor.get_type()))
+                        let row_size = (tensor.get_ne()[0] / ggml::blck_size(tensor.get_type()))
                             as usize
-                            * ggml_type_size(tensor.get_type());
+                            * ggml::type_size(tensor.get_type());
 
                         assert_eq!(row_size, tensor.get_nb()[1]);
 
@@ -645,8 +633,8 @@ impl Model {
                             let offset_row = i1 as usize * row_size;
                             let offset = offset_row
                                 + ((part_id * np0) as usize
-                                    / ggml_blck_size(tensor.get_type()) as usize)
-                                    * ggml_type_size(tensor.get_type());
+                                    / ggml::blck_size(tensor.get_type()) as usize)
+                                    * ggml::type_size(tensor.get_type());
                             // SAFETY: yolo, same as original code
                             unsafe {
                                 let ptr = tensor.data().add(offset);
@@ -659,9 +647,9 @@ impl Model {
                         }
                     } else {
                         let np1 = ne[1];
-                        let row_size = (tensor.get_ne()[0] / ggml_blck_size(tensor.get_type()))
+                        let row_size = (tensor.get_ne()[0] / ggml::blck_size(tensor.get_type()))
                             as usize
-                            * ggml_type_size(tensor.get_type());
+                            * ggml::type_size(tensor.get_type());
 
                         for i1 in 0..ne[1] {
                             let offset_row = (i1 + part_id * np1) as usize * row_size;


### PR DESCRIPTION
Fixes #26.

I removed all references to `ggml_raw` outside of `ggml`, then took the bindgen output, deleted everything that wasn't used, and cleaned it up a little. As you can see, it's not too big.

At the same time, it doesn't look like the original bindgen output is dependent on platform, either. I'm not sure if we should switch over to calling bindgen and committing the output, or maintaining our own C bindings.

Part of me does like the simplicity of knowing *exactly* what we depend on, though.